### PR TITLE
修复百度地图定位不准确的问题

### DIFF
--- a/GMapProvidersExt/Baidu/BaiduProjection.cs
+++ b/GMapProvidersExt/Baidu/BaiduProjection.cs
@@ -9,7 +9,7 @@ namespace GMapProvidersExt.Baidu
     public class BaiduProjection : PureProjection
     {
         // Fields
-        public static readonly BaiduProjection Instance = new BaiduProjection();
+        public static readonly BaiduProjectionJS Instance = new BaiduProjectionJS();
         private static readonly double MinLatitude = -85.05112878;
         private static readonly double MaxLatitude = 85.05112878;
         private static readonly double MinLongitude = -180.0;

--- a/GMapProvidersExt/Baidu/BaiduProjection.cs
+++ b/GMapProvidersExt/Baidu/BaiduProjection.cs
@@ -9,7 +9,7 @@ namespace GMapProvidersExt.Baidu
     public class BaiduProjection : PureProjection
     {
         // Fields
-        public static readonly BaiduProjectionJS Instance = new BaiduProjectionJS();
+        public static readonly BaiduProjection Instance = new BaiduProjection();
         private static readonly double MinLatitude = -85.05112878;
         private static readonly double MaxLatitude = 85.05112878;
         private static readonly double MinLongitude = -180.0;

--- a/GMapProvidersExt/Baidu/BaiduProjectionJS.cs
+++ b/GMapProvidersExt/Baidu/BaiduProjectionJS.cs
@@ -9,7 +9,7 @@ namespace GMapProvidersExt.Baidu
     public class BaiduProjectionJS : PureProjection
     {
         // 百度经纬度 -> 百度墨卡托 -> 像素坐标
-        public static readonly BaiduProjection Instance = new BaiduProjection();
+        public static readonly BaiduProjectionJS Instance = new BaiduProjectionJS();
 
         static readonly double MinLatitude = -74;       // 最小纬度
         static readonly double MaxLatitude = 74;        // 最大纬度


### PR DESCRIPTION
问题：
使用https://api.map.baidu.com/lbsapi/getpoint/index.html拾取百度的坐标，然后用你的下载工具调用位置定位发现位置发生了很大的差距。
比如深圳莲花山的小平同志雕像百度拾取的坐标为：114.066025, 22.558907
然后用你的MapDownloader项目加初始化代码：
mapControl.MapProvider = GMapProvidersExt.Baidu.BaiduMapProvider.Instance;
再增加按钮调用定位代码：
mapControl.Position = new PointLatLng(22.558907, 114.066025);
但是这时候偏到很下面的皇岗村去了。
另一种情况就是，鼠标在地图上移动，地下显示的坐标跟百度的也是完全对不上的。

麻烦您看一下能否解决此问题。

标准坐标转百度坐标测试地址：http://lbsyun.baidu.com/jsdemo.htm#a5_1
PS：官方GMap.NET最新版本是1.7.5

解决方案：将public static readonly BaiduProjection Instance = new BaiduProjection();改为public static readonly BaiduProjectionJS Instance = new BaiduProjectionJS();

另外，如果使用官方1.7.5.0版本的也可以直接用下面项目的百度地图代码继承进去：
参考下这个实现：
https://gitee.com/adodo1/TilesDownloader
http://git.oschina.net/adodo1/TilesDownloader