### PR TITLE
Fix BaiduMap Location Problem

### DIFF
--- a/GMapProvidersExt/Baidu/BaiduMapProviderBase.cs
+++ b/GMapProvidersExt/Baidu/BaiduMapProviderBase.cs
@@ -49,7 +49,7 @@ namespace GMapProvidersExt.Baidu
         {
             get
             {
-                return BaiduProjection.Instance;
+                return BaiduProjectionJS.Instance;
             }
         }
 

--- a/GMapProvidersExt/Baidu/BaiduProjectionJS.cs
+++ b/GMapProvidersExt/Baidu/BaiduProjectionJS.cs
@@ -9,7 +9,7 @@ namespace GMapProvidersExt.Baidu
     public class BaiduProjectionJS : PureProjection
     {
         // 百度经纬度 -> 百度墨卡托 -> 像素坐标
-        public static readonly BaiduProjection Instance = new BaiduProjection();
+        public static readonly BaiduProjectionJS Instance = new BaiduProjectionJS();
 
         static readonly double MinLatitude = -74;       // 最小纬度
         static readonly double MaxLatitude = 74;        // 最大纬度


### PR DESCRIPTION
1、修复BaiduProjectionJS类中对象使用错误问题
2、百度地图统一采用BaiduProjectionJS进行正确偏移的算法类。
PS:greatmap官方最新版本为1.7.5，当前项目采用的还是1.7.0